### PR TITLE
chore: rename shutdown error to stop error

### DIFF
--- a/app/errors.go
+++ b/app/errors.go
@@ -11,8 +11,8 @@ var (
 	// ErrRun indicates a run-time failure.
 	ErrRun = errors.New("run")
 
-	// ErrShutdown indicates a shutdown failure.
-	ErrShutdown = errors.New("shutdown")
+	// ErrStop indicates a stop failure.
+	ErrStop = errors.New("stop")
 )
 
 // SignalError is returned when execution is interrupted by an OS signal.
@@ -37,9 +37,9 @@ func NewErrRun(err error) error {
 	return fmt.Errorf("%w: %w", ErrRun, err)
 }
 
-// NewErrShutdown wraps a shutdown error.
-func NewErrShutdown(err error) error {
-	return fmt.Errorf("%w: %w", ErrShutdown, err)
+// NewErrStop wraps a stop error.
+func NewErrStop(err error) error {
+	return fmt.Errorf("%w: %w", ErrStop, err)
 }
 
 // NewErrSignal creates a new SignalError.

--- a/app/run.go
+++ b/app/run.go
@@ -38,10 +38,10 @@ func Run(ctx context.Context, buildRootCmd func(userDir string) *cobra.Command) 
 	// Execute the root command.
 	if err := cmd.ExecuteContext(ctx); err != nil {
 		isRunErr := utils.ErrorIs(err, ErrRun)
-		isShutdownErr := utils.ErrorIs(err, ErrShutdown)
+		isStopErr := utils.ErrorIs(err, ErrStop)
 
-		// If not already a RunError or ShutdownError, wrap as RunError.
-		if !isRunErr && !isShutdownErr {
+		// If not already a RunError or StopError, wrap as RunError.
+		if !isRunErr && !isStopErr {
 			err = NewErrRun(err)
 		}
 
@@ -51,8 +51,8 @@ func Run(ctx context.Context, buildRootCmd func(userDir string) *cobra.Command) 
 
 		// Print error if:
 		// - it wasn't a signal error (normal failure), OR
-		// - it was a shutdown error triggered by signal.
-		if !isSigErr || isShutdownErr {
+		// - it was a stop error triggered by signal.
+		if !isSigErr || isStopErr {
 			_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal terminology for stop/shutdown handling standardized; no change to user-facing behavior.
* **Tests**
  * Added extensive unit tests and benchmarks covering signal/context handling, error wrapping, run logic, and command execution to improve reliability and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->